### PR TITLE
fix small issue in sql.py which cause AttributeError

### DIFF
--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -284,7 +284,7 @@ class SQL(object):
                 # Disconnect later
                 @flask.current_app.teardown_appcontext
                 def shutdown_session(exception=None):
-                    if flask.g._connection:
+                    if hasattr(flask.g, "_connection") and flask.g._connection:
                         flask.g._connection.close()
 
             # If no connection for context yet


### PR DESCRIPTION
When debug mode is off, sometimes a 
```
AttributeError: '_AppCtxGlobals' object has no attribute '_connection' 
```
is thrown. This is solved by checking that _connection exists in the flask application context before looking up its value.